### PR TITLE
Add MIDDLE_INDEX to dependencies in carousel components

### DIFF
--- a/src/components/HardwareCar.tsx
+++ b/src/components/HardwareCar.tsx
@@ -109,7 +109,7 @@ export default function HardwareServicesCarousel() {
       });
 
     return () => controls.stop();
-  }, [currentIndex, controls, CARD_COUNT, initialX]);
+  }, [currentIndex, controls, CARD_COUNT, initialX, MIDDLE_INDEX]);
 
   if (initialX === null) return null; // Prevent SSR hydration mismatch
 

--- a/src/components/SoftwareCar.tsx
+++ b/src/components/SoftwareCar.tsx
@@ -109,7 +109,7 @@ export default function SoftwareServicesCarousel() {
       });
 
     return () => controls.stop();
-  }, [currentIndex, controls, CARD_COUNT, initialX]);
+  }, [currentIndex, controls, CARD_COUNT, initialX, MIDDLE_INDEX]);
 
   if (initialX === null) return null; // Prevent SSR hydration mismatch
 

--- a/src/components/ThreedCar.tsx
+++ b/src/components/ThreedCar.tsx
@@ -105,7 +105,7 @@ export default function ThreedServicesCarousel() {
       });
 
     return () => controls.stop();
-  }, [currentIndex, controls, CARD_COUNT, initialX]);
+  }, [currentIndex, controls, CARD_COUNT, initialX, MIDDLE_INDEX]);
 
   if (initialX === null) return null; // Prevent SSR hydration mismatch
 


### PR DESCRIPTION
Include MIDDLE_INDEX in the dependency arrays of the carousel components to ensure proper updates when its value changes.