### PR TITLE
Update toast autoClose duration

### DIFF
--- a/src/components/ToastClient.tsx
+++ b/src/components/ToastClient.tsx
@@ -17,7 +17,7 @@ interface ToastClientProps extends ToastOptions {
 export default function ToastClient({
   message,
   type = 'info',
-  autoClose = 3000,
+  autoClose = 1500,
   progressBarColor,
   ...rest
 }: ToastClientProps) {


### PR DESCRIPTION
Reduce the default autoClose duration for toast notifications from 3000ms to 1500ms.