### PR TITLE
Refactor service page data handling

### DIFF
--- a/src/app/(root)/services/[slug]/page.tsx
+++ b/src/app/(root)/services/[slug]/page.tsx
@@ -1,42 +1,49 @@
-import { notFound } from 'next/navigation';
-import { getAllServices, getServiceBySlug } from '@/lib/getServiceData';
-import type { Metadata } from 'next';
-import MotionServicePage from '../../../../components/MotionServicePage'; // ✅ client component
+import { notFound } from "next/navigation";
+import { getAllServices, getServiceBySlug } from "@/lib/getServiceData";
+import type { Metadata } from "next";
+import MotionServicePage from "../../../../components/MotionServicePage"; // ✅ client component
 
 type Props = {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 };
 
-export const dynamicParams = true;
+export const dynamicParams = true; // other slugs can still be dynamic
 
+// 👇 Pre-render `3d-printing-polishing` statically
 export async function generateStaticParams() {
   const services = getAllServices();
-  return services.map((service) => {
-    const slug = service.link?.split('/').pop();
-    return {
-      slug: slug || '3d-printing-polishing',
-    };
-  });
+
+  // ensure `3d-printing-polishing` is always generated
+  const predefined = [{ slug: "3d-printing-polishing" }];
+
+  const dynamicServices = services
+    .map((service) => {
+      const slug = service.link?.split("/").pop();
+      return slug ? { slug } : null;
+    })
+    .filter(Boolean) as { slug: string }[];
+
+  return [...predefined, ...dynamicServices];
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { slug } = await params;
+  const { slug } = params;
   const service = await getServiceBySlug(slug);
 
   if (!service) {
     return {
-      title: 'Service Not Found | Helekin',
+      title: "Service Not Found | Helekin",
     };
   }
 
   return {
     title: `${service.title} | Helekin`,
-    description: service['about-desc'],
+    description: service["about-desc"],
   };
 }
 
 export default async function ServicePage({ params }: Props) {
-  const { slug } = await params;
+  const { slug } = params;
   const service = await getServiceBySlug(slug);
 
   if (!service) return notFound();


### PR DESCRIPTION
Improve the static parameter generation for the service page and ensure the slug for `3d-printing-polishing` is always included. Update the metadata generation to streamline the handling of service data.